### PR TITLE
Remove indirect notation.

### DIFF
--- a/LongDouble.pm
+++ b/LongDouble.pm
@@ -62,7 +62,7 @@ use subs qw(
 our $VERSION = '0.23';
 #$VERSION = eval $VERSION;
 
-DynaLoader::bootstrap Math::LongDouble $Math::LongDouble::VERSION;
+Math::LongDouble->DynaLoader::bootstrap($Math::LongDouble::VERSION);
 
 @Math::LongDouble::EXPORT = ();
 @Math::LongDouble::EXPORT_OK = qw(

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -112,7 +112,7 @@ sleep 1;
 
 print WR "build output (nan**0 check):\n$out\n" if $open;
 
-$diag = $^O =~ /mswin32/i ? `try2.exe nan 0 2>&1` : `./try2.exe nan 0 2>&1`;
+my $diag = $^O =~ /mswin32/i ? `try2.exe nan 0 2>&1` : `./try2.exe nan 0 2>&1`;
 
 print WR "nan**0 check diagnostic: $diag\n" if ($open && defined $diag);
 

--- a/t/new.t
+++ b/t/new.t
@@ -88,15 +88,15 @@ else {
   print "not ok 10\n";
 }
 
-$uv = new Math::LongDouble(~0);
+$uv = Math::LongDouble->new(~0);
 if($uv == UVtoLD(~0)) {print "ok 11\n"}
 else {
   warn "New: $uv\nUVtoLD: ", UVtoLD(~0), "\n";
   print "not ok 11\n";
 }
 
-$iv = new Math::LongDouble(-23);
-$pv = new Math::LongDouble('-23');
+$iv = Math::LongDouble->new(-23);
+$pv = Math::LongDouble->new('-23');
 
 if($pv == $iv){print "ok 12\n"}
 else {
@@ -104,8 +104,8 @@ else {
   print "not ok 12\n";
 }
 
-$pv += new Math::LongDouble(0.5);
-$nv =  new Math::LongDouble(-22.5);
+$pv += Math::LongDouble->new(0.5);
+$nv =  Math::LongDouble->new(-22.5);
 
 if($pv == $nv) {print "ok 13\n"}
 else {
@@ -121,7 +121,7 @@ else {
   print "not ok 14\n";
 }
 
-$pv_copy2 = new Math::LongDouble($pv);
+$pv_copy2 = Math::LongDouble->new($pv);
 
 if($pv == $pv_copy2) {print "ok 15\n"}
 else {


### PR DESCRIPTION
This patch removes indirect notation from the `LongDouble.pm` and one test.   Indirect is problematic, and may be removed from future versions of Perl:
https://shadow.cat/blog/matt-s-trout/indirect-but-still-fatal/

I've also added a `my` to `Makefile.PL` which makes it work under `use strict`.

These changes make this dist work under the experimental Perl 7 branch, which is admittedly still up in the air, but I think these are good practices regardless.